### PR TITLE
Fix bottom sheet position on small screens

### DIFF
--- a/src/components/Home/NewsBottomSheet.tsx
+++ b/src/components/Home/NewsBottomSheet.tsx
@@ -84,7 +84,7 @@ export const NewsBottomSheet: FC = () => {
             index={isNewsClosed ? 0 : 1}
             snapPoints={[
                 // 0 is at the bottom of the screen
-                getUsableScreenHeight() - distanceFromTop.closed,
+                Math.max(getUsableScreenHeight() - distanceFromTop.closed, 42),
                 getUsableScreenHeight() - distanceFromTop.opened,
             ]}
             animateOnMount={false} // app should begin stationary


### PR DESCRIPTION
Ho fixato quel bug fatale sul bottom sheet che riguarda solo gli schermi piccoli (telefoni vecchi) di cui si parlava ieri sul discord. Praticamente la posizione di quando è chiuso viene sempre calcolata allo stesso modo, ma non va oltre ai 42px dal basso

Diciamo che è una soluzione parziale al problema, perché comunque penso che dovremmo riadattare anche le dimensioni di tutti gli altri componenti della home page (che altrimenti magari non entrano nello schermo e sforano verso il basso)

Una cosa del tipo: sopra i 600px (circa) di altezza del telefono i margini, padding, altezze ecc... restano come sono adesso, mentre sotto i 600px facciamo qualcosa di dinamico?

Non so quanto sia utile effettivamente, perché non so se qualcuno usi un telefono così vecchio, però bo...