### PR TITLE
fix image size and title colors

### DIFF
--- a/src/pages/news/ArticleDetails.tsx
+++ b/src/pages/news/ArticleDetails.tsx
@@ -89,6 +89,22 @@ export const Article: MainStackScreen<"Article"> = props => {
                     a {
                         color: ${isLight ? "black" : "white"};
                       }
+                    h1 {
+                        color: ${isLight ? "black" : "white"};
+                    }
+                    h2 {
+                        color: ${isLight ? "black" : "white"};
+                    }
+                    h3 {
+                        color: ${isLight ? "black" : "white"};
+                        text-align: justify;
+                    }
+                    img { 
+                        display: block; max-width: 100%; height: auto;
+                    }
+                    iframe { 
+                        display: block; max-width: 100%; height: auto;
+                    }
                   </style></head><body><div>${html
                       .map(el => `<p>${el}<p/>`)
                       .join("")}


### PR DESCRIPTION
Ho risolto aggiungendo degli style css ad iframe, img per la questione delle immagini e dei video di dimensioni troppo grandi; e degli style h1, h2 e h3 per far cambiare colore ai titoli.

Una cosa: non ho messo come allineamento del testo giustificato agli h1 e h2 perchè mi sembrava brutto (si allarga troppo lo spazio tra i caratteri). Mentre ho messo giustificato per gli h3, come sono già i paragrafi.

fix #124 

fix #125 