### PR TITLE
feature/CU-862jeq3th - Prevent Dependabot from attempting an EAS update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ jobs:
   publish:
     name: Publish via EAS updates
     runs-on: ubuntu-20.04
+    # only run if expo token is set
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -18,8 +21,10 @@ jobs:
         with:
           expo-version: latest
           eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
+          token: ${{ env.EXPO_TOKEN }}
 
       - run: yarn install --immutable
       - name: Publish via EAS updates
+        # only if token is set
+        if: ${{ env.EXPO_TOKEN != '' }}
         run: eas update --auto


### PR DESCRIPTION
closes #191

Credo che questa cosa basti per non far tentare l'update in caso il token non sia valido, e.g quando dependabot causa un push e il token non è leggibile dai secrets, non ho voglia di testare tbh lol